### PR TITLE
Museum recommend exhibits

### DIFF
--- a/lib/museum.rb
+++ b/lib/museum.rb
@@ -9,4 +9,10 @@ class Museum
   def add_exhibit(exhibit)
     exhibits << exhibit
   end
+
+  def recommend_exhibits(patron)
+    exhibits.find_all do |exhibit|
+      patron.interests.include?(exhibit.name)
+    end
+  end
 end

--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -8,6 +8,8 @@ class MuseumTest < Minitest::Test
     @gems_and_minerals = Exhibit.new("Gems and Minerals", 0)
     @dead_sea_scrolls = Exhibit.new("Dead Sea Scrolls", 10)
     @imax = Exhibit.new("IMAX", 15)
+    @bob = Patron.new("Bob", 20)
+    @sally = Patron.new("Sally", 20)
   end
 
   def test_it_exists
@@ -25,5 +27,14 @@ class MuseumTest < Minitest::Test
     @denver.add_exhibit(@imax)
 
     assert_equal [@gems_and_minerals, @dead_sea_scrolls, @imax], @denver.exhibits
+  end
+
+  def test_it_can_suggest_exhibits_for_patrons
+    @bob.add_interest("Dead Sea Scrolls")
+    @bob.add_interest("Gems and Minerals")
+    @sally.add_interest("IMAX")
+
+    assert_equal [@gems_and_minerals, @dead_sea_scrolls], @denver.recommend_exhibits(@bob)
+    assert_equal [@imax], @denver.recommend_exhibits(@sally)
   end
 end

--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -2,6 +2,7 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/museum'
 require './lib/exhibit'
+require './lib/patron'
 class MuseumTest < Minitest::Test
   def setup
     @denver = Museum.new("Denver Museum of Nature and Science")
@@ -33,6 +34,10 @@ class MuseumTest < Minitest::Test
     @bob.add_interest("Dead Sea Scrolls")
     @bob.add_interest("Gems and Minerals")
     @sally.add_interest("IMAX")
+
+    @denver.add_exhibit(@gems_and_minerals)
+    @denver.add_exhibit(@dead_sea_scrolls)
+    @denver.add_exhibit(@imax)
 
     assert_equal [@gems_and_minerals, @dead_sea_scrolls], @denver.recommend_exhibits(@bob)
     assert_equal [@imax], @denver.recommend_exhibits(@sally)


### PR DESCRIPTION
The Recommend Exhibits instance method on Museum takes a specific Patron object, and cross references their Interests with the available Exhibits in the Museum. This will then return an Array of matching Exhibits that the Patron would be inclined to go to.