### PR TITLE
Museum patrons by exhibit interest

### DIFF
--- a/lib/museum.rb
+++ b/lib/museum.rb
@@ -1,9 +1,10 @@
 class Museum
-  attr_reader :name, :exhibits
+  attr_reader :name, :exhibits, :patrons
 
   def initialize(name)
     @name = name
     @exhibits = []
+    @patrons = []
   end
 
   def add_exhibit(exhibit)
@@ -14,5 +15,9 @@ class Museum
     exhibits.find_all do |exhibit|
       patron.interests.include?(exhibit.name)
     end
+  end
+
+  def admit(patron)
+    patrons << patron
   end
 end

--- a/lib/museum.rb
+++ b/lib/museum.rb
@@ -20,4 +20,18 @@ class Museum
   def admit(patron)
     patrons << patron
   end
+
+  def patrons_by_exhibit_interest
+    exhibit_hash = {}
+    exhibits.each do |exhibit|
+      exhibit_hash[exhibit] = []
+      patrons.each do |patron|
+        if patron.interests.include?(exhibit.name)
+          exhibit_hash[exhibit] << patron
+        end
+      end
+    end
+    exhibit_hash
+  end
+
 end

--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -52,4 +52,21 @@ class MuseumTest < Minitest::Test
     assert_equal [@bob, @sally], @denver.patrons
   end
 
+  def test_it_returns_patrons_by_exhibit_interest
+    @bob.add_interest("Dead Sea Scrolls")
+    @bob.add_interest("Gems and Minerals")
+    @sally.add_interest("IMAX")
+
+    @denver.add_exhibit(@gems_and_minerals)
+    @denver.add_exhibit(@dead_sea_scrolls)
+    @denver.add_exhibit(@dead_sea_scrolls)
+
+    @denver.admit(@bob)
+    @denver.admit(@sally)
+
+    expected = {@gems_and_minerals => [@bob], @dead_sea_scrolls => [@bob, @sally], @imax => []}
+
+    assert_equal expected, @denver.patrons_by_exhibit_interest
+  end
+
 end

--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -42,4 +42,14 @@ class MuseumTest < Minitest::Test
     assert_equal [@gems_and_minerals, @dead_sea_scrolls], @denver.recommend_exhibits(@bob)
     assert_equal [@imax], @denver.recommend_exhibits(@sally)
   end
+
+  def test_it_can_admin_patrons
+    assert_equal [], @denver.patrons
+
+    @denver.admit(@bob)
+    @denver.admit(@sally)
+
+    assert_equal [@bob, @sally], @denver.patrons
+  end
+
 end

--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -55,11 +55,11 @@ class MuseumTest < Minitest::Test
   def test_it_returns_patrons_by_exhibit_interest
     @bob.add_interest("Dead Sea Scrolls")
     @bob.add_interest("Gems and Minerals")
-    @sally.add_interest("IMAX")
+    @sally.add_interest("Dead Sea Scrolls")
 
     @denver.add_exhibit(@gems_and_minerals)
     @denver.add_exhibit(@dead_sea_scrolls)
-    @denver.add_exhibit(@dead_sea_scrolls)
+    @denver.add_exhibit(@imax)
 
     @denver.admit(@bob)
     @denver.admit(@sally)


### PR DESCRIPTION
This PR brings in two instance methods for the Museum class, one to Admit Patrons into the Museum, and one to return a list Exhibits and the Patrons would be interested in them.
The Admit method takes a Patron object, and stores them in a Patrons Array on the instance of Museum.
The Patrons by Exhibit Interest method cross references the collection of Patrons and collection of Exhibits, returning a Hash of Exhibits, with an individual Exhibit as the Key, and the Patrons (in an array) who are interested in each Exhibit as the Value.